### PR TITLE
BUG: Prevent crashes by not using vtkMRMLScene::CreateNodeByClass in pyt...

### DIFF
--- a/Py/qSlicerMultiVolumeExplorerModuleWidget.py
+++ b/Py/qSlicerMultiVolumeExplorerModuleWidget.py
@@ -29,13 +29,10 @@ class qSlicerMultiVolumeExplorerModuleWidget:
     self.__cvn = cvns.GetNextItemAsObject()
 
     # data node
-    #self.__dn = slicer.mrmlScene.CreateNodeByClass('vtkMRMLDoubleArrayNode')
-    #self.__dn = slicer.mrmlScene.AddNode(self.__dn)
+    #slicer.mrmlScene.AddNode(slicer.vtkMRMLDoubleArrayNode())
 
     # chart node
-    self.__cn = slicer.mrmlScene.CreateNodeByClass('vtkMRMLChartNode')
-    cn = slicer.mrmlScene.AddNode(self.__cn)
-    self.__cn.SetReferenceCount(1)
+    slicer.mrmlScene.AddNode(slicer.vtkMRMLChartNode())
 
     # image play setup
     self.timer = qt.QTimer()


### PR DESCRIPTION
...hon

As explained in slicer commit r19772, using CreateNodeByClass could easily lead
to bugs and crashes.

See http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=19772
