### PR TITLE
STYLE: Prevent confusion by removing extra CMake message statement

### DIFF
--- a/Testing/Cxx/CMakeLists.txt
+++ b/Testing/Cxx/CMakeLists.txt
@@ -19,8 +19,6 @@ set(LIBRARY_NAME qSlicer${KIT}Module)
 
 add_executable(${KIT}CxxTests ${Tests})
 
-MESSAGE("Added executable ${KIT}CxxTests")
-
 target_link_libraries(${KIT}CxxTests ${lib_name})
 
 foreach(testname ${KIT_TEST_NAMES})


### PR DESCRIPTION
Since the module is currently configured and built when Slicer is,
adding such message appears while configuring Slicer itself.

While it could be useful when the initial layout of the module is
established, this information now reveals to "pollute" the configuration
output of Slicer.
