### PR TITLE
ENH: Using factory method to register MultiVolumeStorage node usage

### DIFF
--- a/Logic/vtkSlicerMultiVolumeExplorerLogic.cxx
+++ b/Logic/vtkSlicerMultiVolumeExplorerLogic.cxx
@@ -111,6 +111,44 @@ void vtkSlicerMultiVolumeExplorerLogic
 {
 }
 
+namespace {
+
+ArchetypeVolumeNodeSet MultiVolumeNodeSetFactory(std::string& volumeName, vtkMRMLScene* scene, int options)
+{
+  ArchetypeVolumeNodeSet nodeSet(scene);
+
+  // set up the scalar node's support nodes
+  vtkNew<vtkMRMLMultiVolumeNode> multiVolumeNode;
+  multiVolumeNode->SetName(volumeName.c_str());
+  nodeSet.Scene->AddNode(multiVolumeNode.GetPointer());
+
+  vtkNew<vtkMRMLMultiVolumeDisplayNode> mdisplayNode;
+  nodeSet.Scene->AddNode(mdisplayNode.GetPointer());
+  multiVolumeNode->SetAndObserveDisplayNodeID(mdisplayNode->GetID());
+
+  vtkNew<vtkMRMLMultiVolumeStorageNode> storageNode;
+  storageNode->SetCenterImage(options & vtkSlicerVolumesLogic::CenterImage);
+  nodeSet.Scene->AddNode(storageNode.GetPointer());
+  multiVolumeNode->SetAndObserveStorageNodeID(storageNode->GetID());
+
+  nodeSet.StorageNode = storageNode.GetPointer();
+  nodeSet.DisplayNode = mdisplayNode.GetPointer();
+  nodeSet.Node = multiVolumeNode.GetPointer();
+
+  return nodeSet;
+}
+
+};
+
+//----------------------------------------------------------------------------
+void vtkSlicerMultiVolumeExplorerLogic::RegisterArchetypeVolumeNodeSetFactory(vtkSlicerVolumesLogic* volumesLogic)
+{
+  if (volumesLogic)
+    {
+    volumesLogic->PreRegisterArchetypeVolumeNodeSetFactory(MultiVolumeNodeSetFactory);
+    }
+}
+
 //----------------------------------------------------------------------------
 void vtkSlicerMultiVolumeExplorerLogic::RegisterNodes()
 {

--- a/Logic/vtkSlicerMultiVolumeExplorerLogic.h
+++ b/Logic/vtkSlicerMultiVolumeExplorerLogic.h
@@ -40,6 +40,7 @@ class vtkMRMLScalarVolumeNode;
 class vtkMRMLVolumeArchetypeStorageNode;
 class vtkMRMLScalarVolumeDisplayNode;
 class vtkMRMLMultiVolumeNode;
+class vtkSlicerVolumesLogic;
 
 /// \ingroup Slicer_QtModules_ExtensionTemplate
 class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_LOGIC_EXPORT vtkSlicerMultiVolumeExplorerLogic :
@@ -57,6 +58,10 @@ public:
                          std::string dcmTag, vtkDoubleArray*);
 
   int InitializeMultivolumeNode(vtkStringArray*, vtkMRMLMultiVolumeNode*);
+
+  /// Register the factory that the MultiVolume needs to manage nrrd
+  /// file with the specified volumes logic
+  void RegisterArchetypeVolumeNodeSetFactory(vtkSlicerVolumesLogic* volumesLogic);
 
 protected:
   vtkSlicerMultiVolumeExplorerLogic();

--- a/MRML/vtkMRMLMultiVolumeStorageNode.cxx
+++ b/MRML/vtkMRMLMultiVolumeStorageNode.cxx
@@ -15,6 +15,8 @@ Version:   $Revision: 1.6 $
 #include "vtkMRMLMultiVolumeStorageNode.h"
 #include "vtkMRMLMultiVolumeNode.h"
 
+#include "vtkNRRDReader.h"
+
 #include "vtkObjectFactory.h"
 
 
@@ -36,4 +38,57 @@ bool vtkMRMLMultiVolumeStorageNode::CanReadInReferenceNode(vtkMRMLNode *refNode)
 {
   return this->vtkMRMLNRRDStorageNode::CanReadInReferenceNode(refNode) || 
     refNode->IsA("vtkMRMLMultiVolumeNode");
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLMultiVolumeStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
+{
+  vtkSmartPointer<vtkNRRDReader> reader =  vtkSmartPointer<vtkNRRDReader>::New();
+
+  if (!this->CanReadInReferenceNode(refNode))
+    {
+    return 0;
+    }
+  
+  std::string fullName = this->GetFullNameFromFileName();
+  if (fullName == std::string("")) 
+    {
+    vtkErrorMacro("ReadData: File name not specified");
+    return 0;
+    }
+
+  reader->SetFileName(fullName.c_str());
+
+  // Check if this is a NRRD file that we can read
+  if (!reader->CanReadFile(fullName.c_str()))
+    {
+    vtkDebugMacro("vtkMRMLNRRDStorageNode: This is not a nrrd file");
+    return 0;
+    }
+
+  // Read the header to see if the NRRD file corresponds to the
+  // MRML Node
+  reader->UpdateInformation();
+  
+  // Check to see if the information contains MultiVolume attributes
+  typedef std::vector<std::string> KeyVector;
+  KeyVector keys = reader->GetHeaderKeysVector();
+  KeyVector::iterator kit = std::find(keys.begin(), keys.end(), "MultiVolume.NumberOfFrames");
+  if (kit == keys.end())
+    {
+    // not a MultiVolume file
+    return 0;
+    }
+  else
+    {
+    // verified as a MultiVolume file.  need to set the number of frames.
+    vtkMRMLMultiVolumeNode* mvNode = dynamic_cast<vtkMRMLMultiVolumeNode*>(refNode);
+    if (mvNode)
+      {
+      mvNode->SetNumberOfFrames(atoi(reader->GetHeaderValue("MultiVolume.NumberOfFrames")));
+      }
+    }
+  
+  // delegate to the superclass
+  return Superclass::ReadDataInternal(refNode);
 }

--- a/MRML/vtkMRMLMultiVolumeStorageNode.h
+++ b/MRML/vtkMRMLMultiVolumeStorageNode.h
@@ -45,6 +45,13 @@ protected:
   ~vtkMRMLMultiVolumeStorageNode();
   vtkMRMLMultiVolumeStorageNode(const vtkMRMLMultiVolumeStorageNode&);
   void operator=(const vtkMRMLMultiVolumeStorageNode&);
+
+  /// Does the actual reading. Returns 1 on success, 0 otherwise.
+  /// Returns 0 by default (read not supported).
+  /// This implementation delegates most everything to the superclass
+  /// but it has an early exit if the file to be read is not a
+  /// MultiVolume, e.g. the file is a NRRD but not a MultiVolume NRRD.
+  virtual int ReadDataInternal(vtkMRMLNode* refNode);
 };
 
 #endif

--- a/qSlicerMultiVolumeExplorerModule.cxx
+++ b/qSlicerMultiVolumeExplorerModule.cxx
@@ -20,6 +20,9 @@
 #include <QScopedPointer>
 #include <QtPlugin>
 
+// Slicer includes
+#include <vtkSlicerVolumesLogic.h>
+
 // MultiVolumeExplorer Logic includes
 #include <vtkSlicerMultiVolumeExplorerLogic.h>
 
@@ -30,6 +33,7 @@
 #include <qSlicerUtils.h>
 #include <qSlicerModuleManager.h>
 #include <qSlicerScriptedLoadableModuleWidget.h>
+#include <qSlicerApplication.h>
 #include <vtkSlicerConfigure.h>
 
 //-----------------------------------------------------------------------------
@@ -114,6 +118,20 @@ QStringList qSlicerMultiVolumeExplorerModule::contributors()const
 void qSlicerMultiVolumeExplorerModule::setup()
 {
   this->Superclass::setup();
+
+  // Register the IO module for loading MultiVolumes as a variant of nrrd files
+  qSlicerAbstractCoreModule* volumes = qSlicerApplication::application()->moduleManager()->module("Volumes");
+  if (volumes)
+    {
+    vtkSlicerVolumesLogic* volumesLogic 
+      = dynamic_cast<vtkSlicerVolumesLogic*>(volumes->logic());
+    vtkSlicerMultiVolumeExplorerLogic* logic
+      = dynamic_cast<vtkSlicerMultiVolumeExplorerLogic*>(this->logic());
+    if (volumesLogic && logic)
+      {
+      logic->RegisterArchetypeVolumeNodeSetFactory( volumesLogic );
+      }
+    }
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
MultiVolumeLogic registers a factory method with the VolumesLogic to
create and configure a triple of a volume node, display node, and
storage node.

Storage node extended such that it checks if the file is a MultiVolume
variant of NRRD.

This can only be used once the Slicer repo is updated.
