### PR TITLE
ENH: Support VTK6.

### DIFF
--- a/MRML/CMakeLists.txt
+++ b/MRML/CMakeLists.txt
@@ -4,6 +4,7 @@ set(module_mrml_name "${PROJECT_NAME}")
 
 set(module_mrml_include_directory
   )
+include_directories(BEFORE ${vtkTeem_INCLUDE_DIRS})
 
 set(module_mrml_SRCS
   vtkMRMLMultiVolumeNode.cxx
@@ -24,7 +25,7 @@ set(module_mrml_export_directive "VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXP
 
 set(module_mrml_target_libraries
   ${MRML_LIBRARIES}
-  ${VTK_LIBRARIES}
+  ${vtkTeem_LIBRARIES}
   )
 
 SlicerMacroBuildModuleMRML(

--- a/MRML/vtkMRMLMultiVolumeDisplayNode.cxx
+++ b/MRML/vtkMRMLMultiVolumeDisplayNode.cxx
@@ -16,6 +16,7 @@ Version:   $Revision: 1.2 $
 #include "vtkMRMLMultiVolumeDisplayNode.h"
 
 // VTK includes
+#include <vtkAlgorithmOutput.h>
 #include <vtkImageAppendComponents.h>
 #include <vtkImageData.h>
 #include <vtkImageExtractComponents.h>
@@ -35,8 +36,13 @@ vtkMRMLMultiVolumeDisplayNode::vtkMRMLMultiVolumeDisplayNode()
   // Strings
   this->FrameComponent = 0;
   this->ExtractComponent = vtkImageExtractComponents::New();
+#if (VTK_MAJOR_VERSION <= 5)
   this->Threshold->SetInput( this->ExtractComponent->GetOutput());
   this->MapToWindowLevelColors->SetInput( this->ExtractComponent->GetOutput());
+#else
+  this->Threshold->SetInputConnection(this->ExtractComponent->GetOutputPort());
+  this->MapToWindowLevelColors->SetInputConnection(this->ExtractComponent->GetOutputPort());
+#endif
 
 }
 
@@ -107,23 +113,45 @@ void vtkMRMLMultiVolumeDisplayNode::PrintSelf(ostream& os, vtkIndent indent)
 }
 
 //----------------------------------------------------------------------------
+#if (VTK_MAJOR_VERSION <= 5)
 void vtkMRMLMultiVolumeDisplayNode
 ::SetInputToImageDataPipeline(vtkImageData *imageData)
 {
   this->ExtractComponent->SetInput(imageData);
 }
+#else
+void vtkMRMLMultiVolumeDisplayNode
+::SetInputToImageDataPipeline(vtkAlgorithmOutput *imageDataConnection)
+{
+  this->ExtractComponent->SetInputConnection(imageDataConnection);
+}
+#endif
 
 //----------------------------------------------------------------------------
+#if (VTK_MAJOR_VERSION <= 5)
 vtkImageData* vtkMRMLMultiVolumeDisplayNode::GetInputImageData()
 {
   return vtkImageData::SafeDownCast(this->ExtractComponent->GetInput());
 }
+#else
+vtkAlgorithmOutput* vtkMRMLMultiVolumeDisplayNode::GetInputImageDataConnection()
+{
+  return this->ExtractComponent->GetInputConnection(0,0);
+}
+#endif
 
 //----------------------------------------------------------------------------
+#if (VTK_MAJOR_VERSION <= 5)
 vtkImageData* vtkMRMLMultiVolumeDisplayNode::GetOutputImageData()
 {
   return this->AppendComponents->GetOutput();
 }
+#else
+vtkAlgorithmOutput* vtkMRMLMultiVolumeDisplayNode::GetOutputImageDataConnection()
+{
+  return this->AppendComponents->GetOutputPort();
+}
+#endif
 
 //---------------------------------------------------------------------------
 vtkImageData* vtkMRMLMultiVolumeDisplayNode::GetScalarImageData()

--- a/MRML/vtkMRMLMultiVolumeDisplayNode.h
+++ b/MRML/vtkMRMLMultiVolumeDisplayNode.h
@@ -31,6 +31,7 @@
 #include "vtkMRMLScalarVolumeDisplayNode.h"
 
 // VTK includes
+class vtkAlgorithmOutput;
 class vtkImageData;
 class vtkImageExtractComponents;
 
@@ -61,12 +62,20 @@ class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXPORT vtkMRMLMultiVolumeDispla
 
   /// 
   /// Get the pipeline input
+#if (VTK_MAJOR_VERSION <= 5)
   virtual vtkImageData* GetInputImageData();
-
+#else
+  virtual vtkAlgorithmOutput* GetInputImageDataConnection();
+#endif
   /// 
   /// Get the pipeline output
+#if (VTK_MAJOR_VERSION <= 5)
+  //BTX
   virtual vtkImageData* GetOutputImageData();
-
+  //ETX
+#else
+  virtual vtkAlgorithmOutput* GetOutputImageDataConnection();
+#endif
   virtual void UpdateImageDataPipeline();
 
   //--------------------------------------------------------------------------
@@ -86,7 +95,11 @@ protected:
 
   /// 
   /// Set the input of the pipeline
+#if (VTK_MAJOR_VERSION <= 5)
   virtual void SetInputToImageDataPipeline(vtkImageData *imageData);
+#else
+  virtual void SetInputToImageDataPipeline(vtkAlgorithmOutput *imageDataConnection);
+#endif
 
   virtual vtkImageData* GetScalarImageData();
 

--- a/MRML/vtkMRMLMultiVolumeStorageNode.cxx
+++ b/MRML/vtkMRMLMultiVolumeStorageNode.cxx
@@ -132,7 +132,11 @@ int vtkMRMLMultiVolumeStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
 
   // configure the canonical vtk meta data
   vtkSmartPointer<vtkImageChangeInformation> ici = vtkSmartPointer<vtkImageChangeInformation>::New();
+#if (VTK_MAJOR_VERSION <= 5)
   ici->SetInput (reader->GetOutput());
+#else
+  ici->SetInputConnection(reader->GetOutputPort());
+#endif
   ici->SetOutputSpacing( 1, 1, 1 );
   ici->SetOutputOrigin( 0, 0, 0 );
   ici->Update();


### PR DESCRIPTION
1) Replace SetInput() with SetInputData() and SetInputConnection().
http://www.vtk.org/Wiki/VTK/VTK_6_Migration/Replacement_of_SetInput

2) Refactor functions in vtkMRMLVolumeNode and its subclasses.
Use ImageDataConnection instead of ImageData
