### PR TITLE
COMP: Fix unused-local-typedefs warnings

### DIFF
--- a/Logic/vtkSlicerMultiVolumeExplorerLogic.cxx
+++ b/Logic/vtkSlicerMultiVolumeExplorerLogic.cxx
@@ -185,11 +185,6 @@ int vtkSlicerMultiVolumeExplorerLogic
   // Returns the number of frames sved, and the array of extracted tag values
   // associated with each frame for the MV node.
 
-  typedef itk::GDCMImageIO ImageIOType;
-  typedef itk::GDCMSeriesFileNames InputNamesGeneratorType;
-  typedef short PixelValueType;
-  typedef itk::Image< PixelValueType, 3 > VolumeType;
-  typedef itk::ImageSeriesReader< VolumeType > ReaderType;
   std::string result = "";
   std::vector<DcmDataset*> dcmDatasetVector;
 


### PR DESCRIPTION
vtkSlicerMultiVolumeExplorerLogic.cxx:188:28: warning: typedef ‘ImageIOType’ locally defined but not used [-Wunused-local-typedefs]
   typedef itk::GDCMImageIO ImageIOType;
                            ^
vtkSlicerMultiVolumeExplorerLogic.cxx:189:36: warning: typedef ‘InputNamesGeneratorType’ locally defined but not used [-Wunused-local-typedefs]
   typedef itk::GDCMSeriesFileNames InputNamesGeneratorType;
                                    ^
vtkSlicerMultiVolumeExplorerLogic.cxx:192:48: warning: typedef ‘ReaderType’ locally defined but not used [-Wunused-local-typedefs]
   typedef itk::ImageSeriesReader< VolumeType > ReaderType;
