### PR TITLE
COMP: Update CMake version to 3.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.4)
-
-#-----------------------------------------------------------------------------
-# See http://cmake.org/cmake/help/cmake-2-8-docs.html#section_Policies for details
-#-----------------------------------------------------------------------------
-if(POLICY CMP0017)
-  cmake_policy(SET CMP0017 OLD)
-endif()
-if(POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW) # CMake 3.0.0
-endif()
+cmake_minimum_required(VERSION 3.5.0)
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME MultiVolumeExplorer)


### PR DESCRIPTION
This commit removes explicit setting of CMake policies.

Note that the setting of CMP0017 to OLD is not needed.

See Slicer/Slicer#765