### PR TITLE
COMP Fix 'inconsistent-missing-override' warnings

### DIFF
--- a/Logic/vtkSlicerMultiVolumeExplorerLogic.h
+++ b/Logic/vtkSlicerMultiVolumeExplorerLogic.h
@@ -50,7 +50,7 @@ public:
 
   static vtkSlicerMultiVolumeExplorerLogic *New();
   vtkTypeMacro(vtkSlicerMultiVolumeExplorerLogic, vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
   /// Initialize listening to MRML events
   void InitializeEventListeners();
@@ -66,11 +66,11 @@ protected:
   virtual ~vtkSlicerMultiVolumeExplorerLogic();
 
   /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.
-  virtual void RegisterNodes();
+  virtual void RegisterNodes() VTK_OVERRIDE;
 
-  virtual void UpdateFromMRMLScene();
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node);
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node);
+  virtual void UpdateFromMRMLScene() VTK_OVERRIDE;
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) VTK_OVERRIDE;
   void StoreVolumeNode(const std::vector<std::string>& filenames,
                        const std::string& seriesFileName);
 private:

--- a/MRML/vtkMRMLMultiVolumeDisplayNode.h
+++ b/MRML/vtkMRMLMultiVolumeDisplayNode.h
@@ -40,32 +40,32 @@ class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXPORT vtkMRMLMultiVolumeDispla
   public:
   static vtkMRMLMultiVolumeDisplayNode *New();
   vtkTypeMacro(vtkMRMLMultiVolumeDisplayNode,vtkMRMLScalarVolumeDisplayNode);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
   /// 
   /// Set node attributes
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
   /// 
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
   /// 
   /// Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node);
+  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
   /// 
   /// Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName() {return "MultiVolumeDisplay";};
+  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "MultiVolumeDisplay";};
 
   /// 
   /// Get the pipeline input
 #if (VTK_MAJOR_VERSION <= 5)
   virtual vtkImageData* GetInputImageData();
 #else
-  virtual vtkAlgorithmOutput* GetInputImageDataConnection();
+  virtual vtkAlgorithmOutput* GetInputImageDataConnection() VTK_OVERRIDE;
 #endif
   /// 
   /// Get the pipeline output
@@ -74,9 +74,9 @@ class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXPORT vtkMRMLMultiVolumeDispla
   virtual vtkImageData* GetOutputImageData();
   //ETX
 #else
-  virtual vtkAlgorithmOutput* GetOutputImageDataConnection();
+  virtual vtkAlgorithmOutput* GetOutputImageDataConnection() VTK_OVERRIDE;
 #endif
-  virtual void UpdateImageDataPipeline();
+  virtual void UpdateImageDataPipeline() VTK_OVERRIDE;
 
   //--------------------------------------------------------------------------
   /// Display Information
@@ -98,7 +98,7 @@ protected:
 #if (VTK_MAJOR_VERSION <= 5)
   virtual void SetInputToImageDataPipeline(vtkImageData *imageData);
 #else
-  virtual void SetInputToImageDataPipeline(vtkAlgorithmOutput *imageDataConnection);
+  virtual void SetInputToImageDataPipeline(vtkAlgorithmOutput *imageDataConnection) VTK_OVERRIDE;
 #endif
 
   virtual vtkImageData* GetScalarImageData();

--- a/MRML/vtkMRMLMultiVolumeNode.h
+++ b/MRML/vtkMRMLMultiVolumeNode.h
@@ -41,21 +41,21 @@ class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXPORT vtkMRMLMultiVolumeNode :
 
   static vtkMRMLMultiVolumeNode *New();
   vtkTypeMacro(vtkMRMLMultiVolumeNode,vtkMRMLScalarVolumeNode);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
   /// Set node attributes
-  virtual void ReadXMLAttributes( const char** atts);
+  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
 
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent);
+  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
 
   /// Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node);
+  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
 
   /// Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName() {return "MRMLMultiVolume";};
+  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "MRMLMultiVolume";};
 
   /// Update the stored reference to another node in the scene
   //virtual void UpdateReferenceID(const char *oldID, const char *newID);
@@ -75,8 +75,8 @@ class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXPORT vtkMRMLMultiVolumeNode :
   std::string GetLabelName();
   void SetLabelName(const std::string& n);
 
-  virtual vtkMRMLStorageNode* CreateDefaultStorageNode();
-  virtual void CreateDefaultDisplayNodes();
+  virtual vtkMRMLStorageNode* CreateDefaultStorageNode() VTK_OVERRIDE;
+  virtual void CreateDefaultDisplayNodes() VTK_OVERRIDE;
   
   vtkMRMLMultiVolumeDisplayNode* GetMultiVolumeDisplayNode();
 

--- a/MRML/vtkMRMLMultiVolumeStorageNode.h
+++ b/MRML/vtkMRMLMultiVolumeStorageNode.h
@@ -31,14 +31,14 @@ class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXPORT vtkMRMLMultiVolumeStorag
   static vtkMRMLMultiVolumeStorageNode *New();
   vtkTypeMacro(vtkMRMLMultiVolumeStorageNode,vtkMRMLNRRDStorageNode);
 
-  virtual vtkMRMLNode* CreateNodeInstance();
+  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
 
   /// 
   /// Get node XML tag name (like Storage, Model)
-  virtual const char* GetNodeTagName()  {return "MultiVolumeStorage";};
+  virtual const char* GetNodeTagName() VTK_OVERRIDE  {return "MultiVolumeStorage";};
 
   /// Return true if the node can be read in.
-  virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode);
+  virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode) VTK_OVERRIDE;
 
 protected:
   vtkMRMLMultiVolumeStorageNode();
@@ -51,7 +51,7 @@ protected:
   /// This implementation delegates most everything to the superclass
   /// but it has an early exit if the file to be read is not a
   /// MultiVolume, e.g. the file is a NRRD but not a MultiVolume NRRD.
-  virtual int ReadDataInternal(vtkMRMLNode* refNode);
+  virtual int ReadDataInternal(vtkMRMLNode* refNode) VTK_OVERRIDE;
 };
 
 #endif


### PR DESCRIPTION
This commit adds the VTK_OVERRIDE macros to fix warnings like the one
reported below occurring when building OpenIGTLink against VTK 8:

In file included from /path/to/Slicer-build/Slicer-build/Modules/Remote/OpenIGTLinkIF/MRML/vtkIGTLToMRMLPointsPython.cxx:12:
In file included from /path/to/Slicer-build/OpenIGTLinkIF/MRML/vtkIGTLToMRMLPoints.h:19:
/path/to/Slicer-build/OpenIGTLinkIF/MRML/vtkIGTLToMRMLBase.h:58:8: warning: 'PrintSelf' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void PrintSelf(ostream& os, vtkIndent indent);
       ^
/path/to/Slicer-build/VTKv8/Common/Core/vtkObject.h:115:8: note: overridden virtual function is here
  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
       ^