### PR TITLE
WIP: add a nifti 4D reader

### DIFF
--- a/MRML/vtkMRMLMultiVolumeStorageNode.cxx
+++ b/MRML/vtkMRMLMultiVolumeStorageNode.cxx
@@ -22,6 +22,8 @@ Version:   $Revision: 1.6 $
 #include "vtkObjectFactory.h"
 #include "vtkImageChangeInformation.h"
 #include "vtkImageData.h"
+#include "vtkNIFTIImageReader.h"
+#include "vtkStringArray.h"
 
 //----------------------------------------------------------------------------
 vtkMRMLNodeNewMacro(vtkMRMLMultiVolumeStorageNode);
@@ -43,6 +45,14 @@ bool vtkMRMLMultiVolumeStorageNode::CanReadInReferenceNode(vtkMRMLNode *refNode)
 }
 
 //----------------------------------------------------------------------------
+void vtkMRMLMultiVolumeStorageNode::InitializeSupportedReadFileTypes()
+{
+  this->Superclass::InitializeSupportedReadFileTypes();
+  this->SupportedReadFileTypes->InsertNextValue("NIfTI (.nii)");
+}
+
+
+//----------------------------------------------------------------------------
 int vtkMRMLMultiVolumeStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
 {
   if (!this->CanReadInReferenceNode(refNode))
@@ -56,14 +66,34 @@ int vtkMRMLMultiVolumeStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
     vtkErrorMacro("ReadDataInternal: not a MultiVolume node.");
     return 0;
     }
-  
+
   std::string fullName = this->GetFullNameFromFileName();
-  if (fullName == std::string("")) 
+  if (fullName == std::string(""))
     {
     vtkErrorMacro("ReadData: File name not specified");
     return 0;
     }
 
+  std::string extension = vtkMRMLStorageNode::GetLowercaseExtensionFromFileName(fullName);
+
+  if (extension == std::string(".nrrd")
+      || extension == std::string(".nhdr") )
+    {
+    return( this->ReadDataInternalNRRD(refNode, volNode, fullName) );
+    }
+
+  if (extension == std::string(".nii"))
+    {
+    return( this->ReadDataInternalNII(refNode, volNode, fullName) );
+    }
+
+  vtkErrorMacro("ReadData: Unrecognized extension");
+  return 0;
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLMultiVolumeStorageNode::ReadDataInternalNRRD(vtkMRMLNode* refNode, vtkMRMLMultiVolumeNode *volNode, std::string fullName)
+{
   vtkSmartPointer<vtkNRRDReader> reader =  vtkSmartPointer<vtkNRRDReader>::New();
   reader->SetFileName(fullName.c_str());
 
@@ -75,7 +105,7 @@ int vtkMRMLMultiVolumeStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
     }
 
   // Set up reader
-  if (this->CenterImage) 
+  if (this->CenterImage)
     {
     reader->SetUseNativeOriginOff();
     }
@@ -87,7 +117,7 @@ int vtkMRMLMultiVolumeStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
   // Read the header to see if the NRRD file corresponds to the
   // MRML Node
   reader->UpdateInformation();
-  
+
   // Check to see if the information contains MultiVolume attributes
   typedef std::vector<std::string> KeyVector;
   KeyVector keys = reader->GetHeaderKeysVector();
@@ -107,12 +137,12 @@ int vtkMRMLMultiVolumeStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
       }
     }
 
-  // 
+  //
   // Finally have verified that we have a MultiVolume nrrd file
   //
 
   // prepare volume node
-  if (volNode->GetImageData()) 
+  if (volNode->GetImageData())
     {
     volNode->SetAndObserveImageData (NULL);
     }
@@ -124,10 +154,105 @@ int vtkMRMLMultiVolumeStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
   vtkMatrix4x4* mat = reader->GetRasToIjkMatrix();
   volNode->SetRASToIJKMatrix(mat);
 
-  // parse non-specific key-value pairs 
+  // parse non-specific key-value pairs
   for ( kit = keys.begin(); kit != keys.end(); ++kit)
     {
-    volNode->SetAttribute((*kit).c_str(), reader->GetHeaderValue((*kit).c_str()));      }
+    volNode->SetAttribute((*kit).c_str(), reader->GetHeaderValue((*kit).c_str()));
+    }
+
+  // configure the canonical vtk meta data
+  vtkSmartPointer<vtkImageChangeInformation> ici = vtkSmartPointer<vtkImageChangeInformation>::New();
+#if (VTK_MAJOR_VERSION <= 5)
+  ici->SetInput (reader->GetOutput());
+#else
+  ici->SetInputConnection(reader->GetOutputPort());
+#endif
+  ici->SetOutputSpacing( 1, 1, 1 );
+  ici->SetOutputOrigin( 0, 0, 0 );
+  ici->Update();
+
+  // assign the buffer
+  volNode->SetAndObserveImageData (ici->GetOutput());
+
+  //
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+int vtkMRMLMultiVolumeStorageNode::ReadDataInternalNII(vtkMRMLNode* refNode, vtkMRMLMultiVolumeNode *volNode, std::string fullName)
+{
+
+  vtkSmartPointer<vtkNIFTIImageReader> reader =  vtkSmartPointer<vtkNIFTIImageReader>::New();
+  reader->SetFileName(fullName.c_str());
+
+  // Check if this is a NRRD file that we can read
+  if (!reader->CanReadFile(fullName.c_str()))
+    {
+    vtkDebugMacro("vtkMRMLMultiVolumeStorageNode: This is not a nii file");
+    return 0;
+    }
+
+  // Set up reader
+  if (this->CenterImage)
+    {
+    vtkErrorMacro("ReadData: Center image option not supported for nii multivolumes");
+    }
+
+  // Read the header to see if the nii file corresponds to the MRML Node
+  reader->SetTimeAsVector(1);
+  reader->UpdateInformation();
+
+  // Check to see if the information contains MultiVolume attributes
+  if (reader->GetNumberOfScalarComponents() < 2)
+    {
+    // not a MultiVolume file
+    return 0;
+    }
+  else
+    {
+    // verified as a MultiVolume file.  need to set the number of frames.
+    vtkMRMLMultiVolumeNode* mvNode = dynamic_cast<vtkMRMLMultiVolumeNode*>(refNode);
+    if (mvNode)
+      {
+      mvNode->SetNumberOfFrames(reader->GetNumberOfScalarComponents());
+      }
+    }
+
+  //
+  // Finally have verified that we have a MultiVolume nii file
+  //
+
+  // prepare volume node
+  if (volNode->GetImageData())
+    {
+    volNode->SetAndObserveImageData (NULL);
+    }
+
+  // Read the volume
+  reader->Update();
+
+  // Define the coordinate frame
+  vtkMatrix4x4* mat = reader->GetQFormMatrix();
+
+  // columns of IJKToRAS
+  volNode->SetIToRASDirection( mat->GetElement(0,0), mat->GetElement(1,0), mat->GetElement(2,0) );
+  if (reader->GetQFac() == -1)
+    {
+    volNode->SetJToRASDirection( mat->GetElement(0,1), mat->GetElement(1,1), mat->GetElement(2,1) );
+    volNode->SetKToRASDirection( mat->GetElement(0,2), mat->GetElement(1,2), mat->GetElement(2,2) );
+    }
+  else
+    {
+    volNode->SetJToRASDirection( -mat->GetElement(0,1), -mat->GetElement(1,1), -mat->GetElement(2,1) );
+    volNode->SetKToRASDirection( -mat->GetElement(0,2), -mat->GetElement(1,2), -mat->GetElement(2,2) );
+    }
+
+  volNode->SetSpacing( reader->GetDataSpacing() );
+
+  // TODO: not correct
+  volNode->SetOrigin( mat->GetElement(0,3), mat->GetElement(1,3), mat->GetElement(2,3) );
+
+  // TODO: populate the other multivolume keys (maybe from json file?)
 
 
   // configure the canonical vtk meta data
@@ -144,6 +269,6 @@ int vtkMRMLMultiVolumeStorageNode::ReadDataInternal(vtkMRMLNode* refNode)
   // assign the buffer
   volNode->SetAndObserveImageData (ici->GetOutput());
 
-  // 
+  //
   return 1;
 }

--- a/MRML/vtkMRMLMultiVolumeStorageNode.h
+++ b/MRML/vtkMRMLMultiVolumeStorageNode.h
@@ -21,6 +21,7 @@
 // MultiVolumeExplorer includes
 #include <vtkSlicerMultiVolumeExplorerModuleMRMLExport.h>
 
+#include "vtkMRMLMultiVolumeNode.h"
 #include "vtkMRMLNRRDStorageNode.h"
 
 /// \ingroup Slicer_QtModules_MultiVolumeNode
@@ -40,6 +41,9 @@ class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXPORT vtkMRMLMultiVolumeStorag
   /// Return true if the node can be read in.
   virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode) VTK_OVERRIDE;
 
+  /// Add nii as extra supported extension
+  virtual void InitializeSupportedReadFileTypes() VTK_OVERRIDE;
+
 protected:
   vtkMRMLMultiVolumeStorageNode();
   ~vtkMRMLMultiVolumeStorageNode();
@@ -52,6 +56,10 @@ protected:
   /// but it has an early exit if the file to be read is not a
   /// MultiVolume, e.g. the file is a NRRD but not a MultiVolume NRRD.
   virtual int ReadDataInternal(vtkMRMLNode* refNode) VTK_OVERRIDE;
+
+  /// Utilities for specific data formats
+  virtual int ReadDataInternalNRRD(vtkMRMLNode* refNode, vtkMRMLMultiVolumeNode *volNode, std::string fullName);
+  virtual int ReadDataInternalNII(vtkMRMLNode* refNode, vtkMRMLMultiVolumeNode *volNode, std::string fullName);
 };
 
 #endif


### PR DESCRIPTION
This adds the option of importing a 4D nifti file as a multivolume.
The data was tested by converting a diffusion dicom file
using dcm2niix.

The geometry of the imported volume appears mostly correct for the
one volume tested (compared with a nrrd file generated from
the same DICOM data)

But there are many issues that have not been tested
and are not correct.  Among them are:

* the tested file has a QFac of -1, but no other values have been tested

* the time spacing is not used

* the multivolume node attributes are not populated

* the loaded pixel values are not the same even though the image
generally looks similar.  Its possible that rescaling has been
done to one of the images but not the other.