### PR TITLE
ENH: Support for Python3

### DIFF
--- a/Py/qSlicerMultiVolumeExplorerCharts.py
+++ b/Py/qSlicerMultiVolumeExplorerCharts.py
@@ -356,7 +356,7 @@ class MultiVolumeIntensityChartView(object):
         val = image.GetScalarComponentAsDouble(ijk[0], ijk[1], ijk[2], c)
         if math.isnan(val):
           val = 0
-        chartTable.SetValue(c, 1, (val / self.baselineAverageSignal - 1) * 100.)
+        chartTable.SetValue(c, 1, int(val / self.baselineAverageSignal - 1) * 100.)
 
   def arePixelsWithinImageExtent(self, image, ijk):
     extent = image.GetExtent()
@@ -475,7 +475,7 @@ class LabeledImageChartView(object):
       if baseline != 0:
         for ic in range(nComponents):
           intensity = arr.GetComponent(ic, 1)
-          percentChange = (intensity / baseline - 1) * 100.
+          percentChange = int(intensity / baseline - 1) * 100.
           arr.SetComponent(ic, 1, percentChange)
 
   def createChartNodeAndInsertData(self):

--- a/Py/qSlicerMultiVolumeExplorerModuleWidget.py
+++ b/Py/qSlicerMultiVolumeExplorerModuleWidget.py
@@ -7,7 +7,7 @@ from qSlicerMultiVolumeExplorerModuleHelper import qSlicerMultiVolumeExplorerMod
 from qSlicerMultiVolumeExplorerCharts import LabeledImageChartView, MultiVolumeIntensityChartView
 
 
-class qSlicerMultiVolumeExplorerSimplifiedModuleWidget:
+class qSlicerMultiVolumeExplorerSimplifiedModuleWidget(object):
 
   def __init__(self, parent=None):
     logging.debug("qSlicerMultiVolumeExplorerSimplifiedModuleWidget:init() called")
@@ -195,7 +195,7 @@ class qSlicerMultiVolumeExplorerSimplifiedModuleWidget:
       # TODO: reset the label text
       return
 
-    if not self.sliceWidgetsPerStyle.has_key(observee):
+    if observee not in self.sliceWidgetsPerStyle:
       return
 
     interactor = observee.GetInteractor()
@@ -219,7 +219,7 @@ class qSlicerMultiVolumeExplorerSimplifiedModuleWidget:
     # get new slice nodes
     layoutManager = slicer.app.layoutManager()
     sliceNodeCount = slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLSliceNode')
-    for nodeIndex in xrange(sliceNodeCount):
+    for nodeIndex in range(sliceNodeCount):
       # find the widget for each node in scene
       sliceNode = slicer.mrmlScene.GetNthNodeByClass(nodeIndex, 'vtkMRMLSliceNode')
       sliceWidget = layoutManager.sliceWidget(sliceNode.GetLayoutName())

--- a/Util/getFrameStats.py
+++ b/Util/getFrameStats.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import helpers
 
 import argparse, sys, shutil, os, slicer
@@ -26,7 +28,7 @@ def main(argv):
     parser.add_argument("-f","--frame",dest="frame",default=0,type=int,required=False,help="Frame to extract statistics")
 
     args = parser.parse_args(argv)
-    print args.frame
+    print(args.frame)
 
     (_,mv) = slicer.util.loadVolume(args.multivolume,returnNode=True)
     (_,label) = slicer.util.loadLabelVolume(args.label,returnNode=True)


### PR DESCRIPTION
Updated code is expected to work with both Python2 and Python3

Slicer migration guide describes how to update the code. See https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide/SlicerExtension#Slicer_5.0:_Python2_to_Python3

This commit was crafted by:

- installing future

```
  Slicer_DIR=/path/to/Slicer-SuperBuild/Slicer-build
  ${Slicer_DIR}/../python-install/bin/PythonSlicer -m pip install
future
```

- applying all fixes

```
  for f in `find ./ -name "*.py"`; do \
    ${Slicer_DIR}/../python-install/bin/PythonSlicer \
      --launch futurize -w $f; \
  done
```

- reviewing the changes and updating as needed.