### PR TITLE
BUG: Python3: Fix splitting of strings

### DIFF
--- a/Py/qSlicerMultiVolumeExplorerCharts.py
+++ b/Py/qSlicerMultiVolumeExplorerCharts.py
@@ -17,7 +17,7 @@ class MultiVolumeIntensityChartView(object):
     nFrames = volumeNode.GetNumberOfFrames()
     mvLabels = [0,]*nFrames
     if frameLabels:
-      mvLabels = string.split(frameLabels,',')
+      mvLabels = frameLabels.split(',')
       if len(mvLabels) == nFrames:
         for l in range(nFrames):
           mvLabels[l] = float(mvLabels[l])


### PR DESCRIPTION
This commit fixes:

```
  AttributeError: module 'string' has no attribute 'split'`
```