### PR TITLE
BUG: Fix crash when opening the module

### DIFF
--- a/Py/qSlicerMultiVolumeExplorerCharts.py
+++ b/Py/qSlicerMultiVolumeExplorerCharts.py
@@ -160,7 +160,6 @@ class MultiVolumeIntensityChartView(object):
     self.__chart.LegendVisibilityOff()
     self.__chart.SetAxisTitleFontSize(15)
     self.__chartViewNode.SetPlotChartNodeID(self.__chart.GetID())
-    self.__chartView.show()
 
     self.__bgxArray = vtk.vtkFloatArray()
     self.__bgyArray = vtk.vtkFloatArray()


### PR DESCRIPTION
On Slicer versions after Sep 9, 2019 on Windows, MultiVolumeExplorer module crashes immediately when the user switches to the module.

Removing showing of the chartView in its constructor fixes the crash.

It is not completely clear why this fix works. Showing a widget in its constructor is very unusual and it created a window flashing effect when opening the module GUI, so it make sense to remove it, but it is unclear why it caused crash (or why it did not cause crash earlier). At that time when the module started to crash, there was a large CTK/PythonQt update. The application does not crash with local development builds (maybe due to different Qt version).