### PR TITLE
STYLE: Remove VTK <= 8 support using override statements for C++11

### DIFF
--- a/Logic/vtkSlicerMultiVolumeExplorerLogic.h
+++ b/Logic/vtkSlicerMultiVolumeExplorerLogic.h
@@ -50,7 +50,7 @@ public:
 
   static vtkSlicerMultiVolumeExplorerLogic *New();
   vtkTypeMacro(vtkSlicerMultiVolumeExplorerLogic, vtkSlicerModuleLogic);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /// Initialize listening to MRML events
   void InitializeEventListeners();
@@ -66,11 +66,11 @@ protected:
   virtual ~vtkSlicerMultiVolumeExplorerLogic();
 
   /// Register MRML Node classes to Scene. Gets called automatically when the MRMLScene is attached to this logic class.
-  virtual void RegisterNodes() VTK_OVERRIDE;
+  virtual void RegisterNodes() override;
 
-  virtual void UpdateFromMRMLScene() VTK_OVERRIDE;
-  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) VTK_OVERRIDE;
-  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) VTK_OVERRIDE;
+  virtual void UpdateFromMRMLScene() override;
+  virtual void OnMRMLSceneNodeAdded(vtkMRMLNode* node) override;
+  virtual void OnMRMLSceneNodeRemoved(vtkMRMLNode* node) override;
   void StoreVolumeNode(const std::vector<std::string>& filenames,
                        const std::string& seriesFileName);
 private:

--- a/MRML/vtkMRMLMultiVolumeDisplayNode.h
+++ b/MRML/vtkMRMLMultiVolumeDisplayNode.h
@@ -40,32 +40,32 @@ class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXPORT vtkMRMLMultiVolumeDispla
   public:
   static vtkMRMLMultiVolumeDisplayNode *New();
   vtkTypeMacro(vtkMRMLMultiVolumeDisplayNode,vtkMRMLScalarVolumeDisplayNode);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNodeInstance() override;
 
   /// 
   /// Set node attributes
-  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
+  virtual void ReadXMLAttributes( const char** atts) override;
 
   /// 
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
+  virtual void WriteXML(ostream& of, int indent) override;
 
   /// 
   /// Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
+  virtual void Copy(vtkMRMLNode *node) override;
 
   /// 
   /// Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "MultiVolumeDisplay";};
+  virtual const char* GetNodeTagName() override {return "MultiVolumeDisplay";};
 
   /// 
   /// Get the pipeline input
 #if (VTK_MAJOR_VERSION <= 5)
   virtual vtkImageData* GetInputImageData();
 #else
-  virtual vtkAlgorithmOutput* GetInputImageDataConnection() VTK_OVERRIDE;
+  virtual vtkAlgorithmOutput* GetInputImageDataConnection() override;
 #endif
   /// 
   /// Get the pipeline output
@@ -74,9 +74,9 @@ class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXPORT vtkMRMLMultiVolumeDispla
   virtual vtkImageData* GetOutputImageData();
   //ETX
 #else
-  virtual vtkAlgorithmOutput* GetOutputImageDataConnection() VTK_OVERRIDE;
+  virtual vtkAlgorithmOutput* GetOutputImageDataConnection() override;
 #endif
-  virtual void UpdateImageDataPipeline() VTK_OVERRIDE;
+  virtual void UpdateImageDataPipeline() override;
 
   //--------------------------------------------------------------------------
   /// Display Information
@@ -98,7 +98,7 @@ protected:
 #if (VTK_MAJOR_VERSION <= 5)
   virtual void SetInputToImageDataPipeline(vtkImageData *imageData);
 #else
-  virtual void SetInputToImageDataPipeline(vtkAlgorithmOutput *imageDataConnection) VTK_OVERRIDE;
+  virtual void SetInputToImageDataPipeline(vtkAlgorithmOutput *imageDataConnection) override;
 #endif
 
   virtual vtkImageData* GetScalarImageData();

--- a/MRML/vtkMRMLMultiVolumeNode.h
+++ b/MRML/vtkMRMLMultiVolumeNode.h
@@ -41,21 +41,21 @@ class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXPORT vtkMRMLMultiVolumeNode :
 
   static vtkMRMLMultiVolumeNode *New();
   vtkTypeMacro(vtkMRMLMultiVolumeNode,vtkMRMLScalarVolumeNode);
-  void PrintSelf(ostream& os, vtkIndent indent) VTK_OVERRIDE;
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
-  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNodeInstance() override;
 
   /// Set node attributes
-  virtual void ReadXMLAttributes( const char** atts) VTK_OVERRIDE;
+  virtual void ReadXMLAttributes( const char** atts) override;
 
   /// Write this node's information to a MRML file in XML format.
-  virtual void WriteXML(ostream& of, int indent) VTK_OVERRIDE;
+  virtual void WriteXML(ostream& of, int indent) override;
 
   /// Copy the node's attributes to this object
-  virtual void Copy(vtkMRMLNode *node) VTK_OVERRIDE;
+  virtual void Copy(vtkMRMLNode *node) override;
 
   /// Get node XML tag name (like Volume, Model)
-  virtual const char* GetNodeTagName() VTK_OVERRIDE {return "MRMLMultiVolume";};
+  virtual const char* GetNodeTagName() override {return "MRMLMultiVolume";};
 
   /// Update the stored reference to another node in the scene
   //virtual void UpdateReferenceID(const char *oldID, const char *newID);
@@ -75,8 +75,8 @@ class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXPORT vtkMRMLMultiVolumeNode :
   std::string GetLabelName();
   void SetLabelName(const std::string& n);
 
-  virtual vtkMRMLStorageNode* CreateDefaultStorageNode() VTK_OVERRIDE;
-  virtual void CreateDefaultDisplayNodes() VTK_OVERRIDE;
+  virtual vtkMRMLStorageNode* CreateDefaultStorageNode() override;
+  virtual void CreateDefaultDisplayNodes() override;
   
   vtkMRMLMultiVolumeDisplayNode* GetMultiVolumeDisplayNode();
 

--- a/MRML/vtkMRMLMultiVolumeStorageNode.h
+++ b/MRML/vtkMRMLMultiVolumeStorageNode.h
@@ -31,14 +31,14 @@ class VTK_SLICER_MULTIVOLUMEEXPLORER_MODULE_MRML_EXPORT vtkMRMLMultiVolumeStorag
   static vtkMRMLMultiVolumeStorageNode *New();
   vtkTypeMacro(vtkMRMLMultiVolumeStorageNode,vtkMRMLNRRDStorageNode);
 
-  virtual vtkMRMLNode* CreateNodeInstance() VTK_OVERRIDE;
+  virtual vtkMRMLNode* CreateNodeInstance() override;
 
   /// 
   /// Get node XML tag name (like Storage, Model)
-  virtual const char* GetNodeTagName() VTK_OVERRIDE  {return "MultiVolumeStorage";};
+  virtual const char* GetNodeTagName() override  {return "MultiVolumeStorage";};
 
   /// Return true if the node can be read in.
-  virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode) VTK_OVERRIDE;
+  virtual bool CanReadInReferenceNode(vtkMRMLNode *refNode) override;
 
 protected:
   vtkMRMLMultiVolumeStorageNode();
@@ -51,7 +51,7 @@ protected:
   /// This implementation delegates most everything to the superclass
   /// but it has an early exit if the file to be read is not a
   /// MultiVolume, e.g. the file is a NRRD but not a MultiVolume NRRD.
-  virtual int ReadDataInternal(vtkMRMLNode* refNode) VTK_OVERRIDE;
+  virtual int ReadDataInternal(vtkMRMLNode* refNode) override;
 };
 
 #endif


### PR DESCRIPTION
This commit is required to build against VTK >= 8.90