### PR TITLE
STYLE: Upgrade python syntax to 3.6 and newer

### DIFF
--- a/Py/qSlicerMultiVolumeExplorerCharts.py
+++ b/Py/qSlicerMultiVolumeExplorerCharts.py
@@ -4,7 +4,7 @@ from qt import QSize
 from qSlicerMultiVolumeExplorerModuleHelper import qSlicerMultiVolumeExplorerModuleHelper as Helper
 
 
-class MultiVolumeIntensityChartView(object):
+class MultiVolumeIntensityChartView:
 
   SIGNAL_INTENSITY_MODE = 0
   FIXED_RANGE_INTENSITY_MODE = 1
@@ -390,7 +390,7 @@ class MultiVolumeIntensityChartView(object):
     self.__chart.SetXAxisTitle(title)
 
 
-class LabeledImageChartView(object):
+class LabeledImageChartView:
 
   def __init__(self, labelNode, multiVolumeNode, multiVolumeLabels, baselineFrames, displayPercentageChange=False):
     self.labelNode = labelNode

--- a/Py/qSlicerMultiVolumeExplorerModuleHelper.py
+++ b/Py/qSlicerMultiVolumeExplorerModuleHelper.py
@@ -2,11 +2,11 @@ from __main__ import slicer
 import vtk
 
 
-class qSlicerMultiVolumeExplorerModuleHelper( object ):
+class qSlicerMultiVolumeExplorerModuleHelper:
 
   @staticmethod
   def RGBtoHex(r, g, b):
-    return '#%02X%02X%02X' % (r,g,b)
+    return f'#{r:02X}{g:02X}{b:02X}'
 
   @staticmethod
   def extractFrame(scalarVolumeNode, multiVolumeNode, frameId):

--- a/Py/qSlicerMultiVolumeExplorerModuleWidget.py
+++ b/Py/qSlicerMultiVolumeExplorerModuleWidget.py
@@ -7,7 +7,7 @@ from qSlicerMultiVolumeExplorerModuleHelper import qSlicerMultiVolumeExplorerMod
 from qSlicerMultiVolumeExplorerCharts import LabeledImageChartView, MultiVolumeIntensityChartView
 
 
-class qSlicerMultiVolumeExplorerSimplifiedModuleWidget(object):
+class qSlicerMultiVolumeExplorerSimplifiedModuleWidget:
 
   def __init__(self, parent=None):
     logging.debug("qSlicerMultiVolumeExplorerSimplifiedModuleWidget:init() called")

--- a/Util/getFrameStats.py
+++ b/Util/getFrameStats.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import helpers
 
 import argparse, sys, shutil, os, slicer


### PR DESCRIPTION
This PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade python syntax to newer versions. This ultimately removes Python 2 compatibility.

See https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MigrationGuide#Supporting_only_Python_3.6_and_above

re: https://github.com/Slicer/Slicer/issues/5626