### PR TITLE
COMP: Remove condition that QT5 or greater is needed

### DIFF
--- a/qSlicerMultiVolumeExplorerModule.h
+++ b/qSlicerMultiVolumeExplorerModule.h
@@ -30,9 +30,7 @@ class Q_SLICER_QTMODULES_MULTIVOLUMEEXPLORER_EXPORT qSlicerMultiVolumeExplorerMo
   public qSlicerLoadableModule
 {
   Q_OBJECT
-#ifdef Slicer_HAVE_QT5
   Q_PLUGIN_METADATA(IID "org.slicer.modules.loadable.qSlicerLoadableModule/1.0");
-#endif
   Q_INTERFACES(qSlicerLoadableModule);
 
 public:


### PR DESCRIPTION
Support for Qt4 is removed, so the Slicer_HAVE_QT5 flag is no longer appropriate.